### PR TITLE
Fix an issue with pod name that doesn't contain a hypen ("-") sign.

### DIFF
--- a/netassert
+++ b/netassert
@@ -96,10 +96,21 @@ get_host() {
   if [[ ! "${HOST}" =~ - ]]; then
     local HOST_CACHE_KEY="HOST_MAP_${HOST//./_}"
     # attempt to detect invalid cache keys :/
+    # this code only works when hypen ("-") sign exists in the string, otherwise we will get bad substitution error
+    if [[ $HOST_CACHE_KEY =~ "-" ]]; then
+      if [[ "${!HOST_CACHE_KEY:-}" != "" ]]; then
+        echo "${!HOST_CACHE_KEY} (${HOST})"
+        return 0
+      fi
+    else
+      echo "No hypen '-' character exists in the HOST_CACHE_KEY: ${HOST_CACHE_KEY}, skip invalid cache key check!"
+    fi
+
     if [[ "${!HOST_CACHE_KEY:-}" != "" ]]; then
       echo "${!HOST_CACHE_KEY} (${HOST})"
       return 0
     fi
+
   fi
 
   echo "${HOST}"


### PR DESCRIPTION
My test.yml:
```bash
k8s:
  deployment:
    zhe:abc:
      google.com: 443
```
And this test will generate a HOST_CACHE_KEY="HOST_MAP_zhe:abc" and fail the `get_host()` function.

You can check it by using this script:
```bash
#!/bin/bash
FOO="HOST_MAP_zhe:abc"
echo "${!FOO}"
```

So I just skip the check when the name doesn't contain "-" for now.